### PR TITLE
fix timezone

### DIFF
--- a/clock.js
+++ b/clock.js
@@ -1,5 +1,9 @@
-setInterval(function() {
-    var hex = '#' + new Date().toISOString().substr(11, 8).replace(/:/g, '');
-    document.getElementById('clock').innerHTML = hex;
-    document.body.style.backgroundColor = hex;
-}, 500); // 0.5s
+setInterval(() => {
+  const today = new Date();
+  const pad = (s) => s.toString().padStart(2, "0");
+
+  const hex = `#${pad(today.getHours())}${pad(today.getMinutes())}${pad(today.getSeconds())}`;
+
+  document.getElementById("clock").innerHTML = hex;
+  document.body.style.backgroundColor = hex;
+}, 500);


### PR DESCRIPTION
Changed from using `.toISOString()` so the time is shown in your local timezone.